### PR TITLE
Making creation of SoyFileSet$Builders extensible

### DIFF
--- a/src/soy_clj/core.clj
+++ b/src/soy_clj/core.clj
@@ -32,14 +32,16 @@
   "Use only the defaults for JS compilation."
   (SoyJsSrcOptions.))
 
+(def ^:dynamic *builder-fn* #(SoyFileSet/builder))
+
 (defn parse-string
   "Given a Closure template as a string, parses it and returns a compiled set of
   templates."
-  [template-str template-name]
-  (let [builder (SoyFileSet/builder)]
-    (.add builder ^String template-str ^String template-name)
-    (.setGeneralOptions builder opts)
-    (.compileToTofu (.build builder))))
+  ([template-str template-name]
+   (let [builder (*builder-fn*)]
+     (.add builder ^String template-str ^String template-name)
+     (.setGeneralOptions builder opts)
+     (.compileToTofu (.build builder)))))
 
 (defn- add-file
   [^SoyFileSet$Builder builder ^String file]
@@ -50,7 +52,7 @@
 (defn- ^SoyFileSet build
   "Builds a fileset from the given files."
   [files]
-  (let [builder (SoyFileSet/builder)]
+  (let [builder (*builder-fn*)]
     (run! (partial add-file builder) files)
     (.setGeneralOptions builder opts)
     (.build builder)))

--- a/test/soy_clj/core_test.clj
+++ b/test/soy_clj/core_test.clj
@@ -1,8 +1,10 @@
 (ns soy-clj.core-test
   (:require [clojure.core.cache :as cache]
+            [clojure.java.io :as io]
             [clojure.string :as string]
             [clojure.test :refer :all]
-            [soy-clj.core :refer :all :as soy-clj]))
+            [soy-clj.core :refer :all :as soy-clj])
+  (:import [com.google.template.soy SoyFileSet SoyFileSet$Builder]))
 
 (deftest content-type-test
   (testing "The content types of various kinds"
@@ -95,3 +97,15 @@
            (render (parse "example.soy") "examples.simple.helloName"
                    {:name (ordain-as-safe "Mr. <i>World<i>" :html)
                     :greeting-word "Bonjour"})))))
+
+(deftest builder-fn-test
+  (testing "the SoyFileSet$Builder factory function can be overridden"
+    (binding [*builder-fn* (fn [] (let [builder (SoyFileSet/builder)]
+                                    (.add builder (io/file "test/example.soy"))
+                                    builder))]
+      (is (= ["Hello, Mr. World!"
+              :text]
+             (render (parse-string "{namespace foo}" "foo.soy")
+                     "examples.simple.exampleText"
+                     {:name "Mr. World"}
+                     :text))))))


### PR DESCRIPTION
The `*builder-fn*` dynamic var can be used to specify a new function to create `SoyFileSet$Builder` instances, which is necessary if you want to install plugins.
